### PR TITLE
feat(be): integrate block explorer Json-RPC server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,12 @@ install:
 	@echo "--> Ensure dependencies have not been modified"
 	@go mod verify
 	@echo "--> installing rollappd"
-	@go install $(BUILD_FLAGS) -v -mod=readonly ./rollappd
+	@go install $(BUILD_FLAGS) -tags be_json_rpc_wasm -v -mod=readonly ./rollappd
 
 
 .PHONY: build
 build: ## Compiles the rollapd binary
-	go build  -o build/rollappd $(BUILD_FLAGS) ./rollappd
+	go build  -o build/rollappd $(BUILD_FLAGS) -tags be_json_rpc_wasm ./rollappd
 
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,12 @@ install:
 	@echo "--> Ensure dependencies have not been modified"
 	@go mod verify
 	@echo "--> installing rollappd"
-	@go install $(BUILD_FLAGS) -tags be_json_rpc_wasm -v -mod=readonly ./rollappd
+	@go install $(BUILD_FLAGS) -v -mod=readonly ./rollappd
 
 
 .PHONY: build
 build: ## Compiles the rollapd binary
-	go build  -o build/rollappd $(BUILD_FLAGS) -tags be_json_rpc_wasm ./rollappd
+	go build  -o build/rollappd $(BUILD_FLAGS) ./rollappd
 
 
 .PHONY: clean

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,15 @@ go 1.22.1
 require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	github.com/CosmWasm/wasmd v0.33.0
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.1
+	github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.1
 	github.com/cosmos/cosmos-sdk v0.46.15
 	github.com/cosmos/ibc-go/v6 v6.2.1
 	github.com/dymensionxyz/dymension-rdk v1.2.0-beta
 	github.com/dymensionxyz/dymint v1.0.1-alpha
+	github.com/ethereum/go-ethereum v1.12.0
 	github.com/gorilla/mux v1.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.5.1
@@ -32,6 +36,7 @@ require (
 	github.com/99designs/keyring v1.2.1 // indirect
 	github.com/ChainSafe/go-schnorrkel v1.0.0 // indirect
 	github.com/CosmWasm/wasmvm v1.3.0 // indirect
+	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/Workiva/go-datastructures v1.0.53 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/avast/retry-go/v4 v4.5.0 // indirect
@@ -90,7 +95,6 @@ require (
 	github.com/dymensionxyz/cosmosclient v0.4.2-beta // indirect
 	github.com/dymensionxyz/dymension/v3 v3.0.0-rc02.0.20240304125623-d447bab68709 // indirect
 	github.com/elastic/gosigar v0.14.2 // indirect
-	github.com/ethereum/go-ethereum v1.12.0 // indirect
 	github.com/evmos/evmos/v12 v12.1.6 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/filecoin-project/go-jsonrpc v0.3.1 // indirect
@@ -103,6 +107,7 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
@@ -212,7 +217,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.7 // indirect
 	github.com/petermattis/goid v0.0.0-20230317030725-371a4b8eda08 // indirect
 	github.com/pierrec/xxHash v0.1.5 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
@@ -228,6 +232,7 @@ require (
 	github.com/rs/cors v1.9.0 // indirect
 	github.com/rs/zerolog v1.29.1 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
+	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
@@ -245,6 +250,8 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
+	github.com/tklauser/go-sysconf v0.3.11 // indirect
+	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
-github.com/allegro/bigcache v1.2.1 h1:hg1sY1raCwic3Vnsvje6TT7/pnZba83LeFck5NrFKSc=
-github.com/allegro/bigcache v1.2.1/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -368,7 +366,6 @@ github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -722,7 +719,6 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb h1:PBC98N2aIaM3XXiurYmW7fx4GZkL8feAMVq7nEjURHk=
@@ -1811,7 +1807,6 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181029174526-d69651ed3497/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,10 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.1 h1:/mkYfjhJSQr71mJUFbOoyRvykSUj6TgwB9m9sKtqtOI=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.1/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.1 h1:Foj4wfN7WLPxxabMrnJXKbjXcB4BpmFdeHzCzb+tGks=
+github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.1/go.mod h1:Lxsmp+l1ivLidAxx/6eZ/aFMeFxpmiOaMbKXPG6yCwI=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
+github.com/allegro/bigcache v1.2.1 h1:hg1sY1raCwic3Vnsvje6TT7/pnZba83LeFck5NrFKSc=
+github.com/allegro/bigcache v1.2.1/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -366,6 +368,7 @@ github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -631,6 +634,7 @@ github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -718,6 +722,7 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb h1:PBC98N2aIaM3XXiurYmW7fx4GZkL8feAMVq7nEjURHk=
@@ -1806,6 +1811,7 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181029174526-d69651ed3497/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1828,6 +1834,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1913,6 +1920,7 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=

--- a/ra_wasm_be_rpc/backend/backend.go
+++ b/ra_wasm_be_rpc/backend/backend.go
@@ -1,0 +1,48 @@
+package backend
+
+import (
+	"context"
+	"github.com/bcdevtools/block-explorer-rpc-cosmos/be_rpc/config"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/server"
+	sequencerstypes "github.com/dymensionxyz/dymension-rdk/x/sequencers/types"
+	rawberpctypes "github.com/dymensionxyz/rollapp-wasm/ra_wasm_be_rpc/types"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+type RollAppWasmBackendI interface {
+	// Misc
+
+	GetSequencersModuleParams() (*sequencerstypes.Params, error)
+}
+
+var _ RollAppWasmBackendI = (*RollAppWasmBackend)(nil)
+
+// RollAppWasmBackend implements the RollAppWasmBackendI interface
+type RollAppWasmBackend struct {
+	ctx         context.Context
+	clientCtx   client.Context
+	queryClient *rawberpctypes.QueryClient // gRPC query client
+	logger      log.Logger
+	cfg         config.BeJsonRpcConfig
+}
+
+// NewRollAppWasmBackend creates a new RollAppWasmBackend instance for RollApp EVM Block Explorer
+func NewRollAppWasmBackend(
+	ctx *server.Context,
+	logger log.Logger,
+	clientCtx client.Context,
+) *RollAppWasmBackend {
+	appConf, err := config.GetConfig(ctx.Viper)
+	if err != nil {
+		panic(err)
+	}
+
+	return &RollAppWasmBackend{
+		ctx:         context.Background(),
+		clientCtx:   clientCtx,
+		queryClient: rawberpctypes.NewQueryClient(clientCtx),
+		logger:      logger.With("module", "raw_be_rpc"),
+		cfg:         appConf,
+	}
+}

--- a/ra_wasm_be_rpc/backend/rollapp_wasm_interceptor.go
+++ b/ra_wasm_be_rpc/backend/rollapp_wasm_interceptor.go
@@ -49,7 +49,6 @@ func (m *RollAppEvmRequestInterceptor) GetModuleParams(moduleName string) (inter
 		} else {
 			params = *sequencersParams
 		}
-		break
 	default:
 		return m.defaultInterceptor.GetModuleParams(moduleName)
 	}

--- a/ra_wasm_be_rpc/backend/rollapp_wasm_interceptor.go
+++ b/ra_wasm_be_rpc/backend/rollapp_wasm_interceptor.go
@@ -1,0 +1,74 @@
+package backend
+
+import (
+	berpcbackend "github.com/bcdevtools/block-explorer-rpc-cosmos/be_rpc/backend"
+	berpctypes "github.com/bcdevtools/block-explorer-rpc-cosmos/be_rpc/types"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var _ berpcbackend.RequestInterceptor = (*RollAppEvmRequestInterceptor)(nil)
+
+type RollAppEvmRequestInterceptor struct {
+	beRpcBackend       berpcbackend.BackendI
+	backend            RollAppWasmBackendI
+	defaultInterceptor berpcbackend.RequestInterceptor
+}
+
+func NewRollAppEvmRequestInterceptor(
+	beRpcBackend berpcbackend.BackendI,
+	backend RollAppWasmBackendI,
+	defaultInterceptor berpcbackend.RequestInterceptor,
+) *RollAppEvmRequestInterceptor {
+	return &RollAppEvmRequestInterceptor{
+		beRpcBackend:       beRpcBackend,
+		backend:            backend,
+		defaultInterceptor: defaultInterceptor,
+	}
+}
+
+func (m *RollAppEvmRequestInterceptor) GetTransactionByHash(hashStr string) (intercepted bool, response berpctypes.GenericBackendResponse, err error) {
+	// handled completely by the default interceptor
+	return m.defaultInterceptor.GetTransactionByHash(hashStr)
+}
+
+func (m *RollAppEvmRequestInterceptor) GetDenomsInformation() (intercepted, append bool, denoms map[string]string, err error) {
+	// handled completely by the default interceptor
+	return m.defaultInterceptor.GetDenomsInformation()
+}
+
+func (m *RollAppEvmRequestInterceptor) GetModuleParams(moduleName string) (intercepted bool, res berpctypes.GenericBackendResponse, err error) {
+	var params any
+
+	switch moduleName {
+	case "sequencers":
+		sequencersParams, errFetch := m.backend.GetSequencersModuleParams()
+		if errFetch != nil {
+			err = errors.Wrap(errFetch, "failed to get sequencers params")
+		} else {
+			params = *sequencersParams
+		}
+		break
+	default:
+		return m.defaultInterceptor.GetModuleParams(moduleName)
+	}
+
+	if err != nil {
+		return
+	}
+
+	res, err = berpctypes.NewGenericBackendResponseFrom(params)
+	if err != nil {
+		err = status.Error(codes.Internal, errors.Wrap(err, "module params").Error())
+		return
+	}
+
+	intercepted = true
+	return
+}
+
+func (m *RollAppEvmRequestInterceptor) GetAccount(accountAddressStr string) (intercepted, append bool, response berpctypes.GenericBackendResponse, err error) {
+	// handled completely by the default interceptor
+	return m.defaultInterceptor.GetAccount(accountAddressStr)
+}

--- a/ra_wasm_be_rpc/backend/sequencers.go
+++ b/ra_wasm_be_rpc/backend/sequencers.go
@@ -1,0 +1,13 @@
+package backend
+
+import (
+	sequencerstypes "github.com/dymensionxyz/dymension-rdk/x/sequencers/types"
+)
+
+func (m *RollAppWasmBackend) GetSequencersModuleParams() (*sequencerstypes.Params, error) {
+	res, err := m.queryClient.SequencersQueryClient.Params(m.ctx, &sequencerstypes.QueryParamsRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return &res.Params, nil
+}

--- a/ra_wasm_be_rpc/namespaces/raw/api.go
+++ b/ra_wasm_be_rpc/namespaces/raw/api.go
@@ -1,0 +1,39 @@
+package raw
+
+import (
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/server"
+	rawberpcbackend "github.com/dymensionxyz/rollapp-wasm/ra_wasm_be_rpc/backend"
+	"github.com/tendermint/tendermint/libs/log"
+)
+
+// RPC namespaces and API version
+const (
+	DymRollAppWasmBlockExplorerNamespace = "raw"
+
+	ApiVersion = "1.0"
+)
+
+// API is the RollApp EVM Block Explorer JSON-RPC.
+type API struct {
+	ctx     *server.Context
+	logger  log.Logger
+	backend rawberpcbackend.RollAppWasmBackendI
+}
+
+// NewRaeAPI creates an instance of the RollApp EVM Block Explorer API.
+func NewRaeAPI(
+	ctx *server.Context,
+	backend rawberpcbackend.RollAppWasmBackendI,
+) *API {
+	return &API{
+		ctx:     ctx,
+		logger:  ctx.Logger.With("api", "raw"),
+		backend: backend,
+	}
+}
+
+func (api *API) Echo(text string) string {
+	api.logger.Debug("raw_echo")
+	return fmt.Sprintf("hello \"%s\" from RollApp Wasm Block Explorer API", text)
+}

--- a/ra_wasm_be_rpc/namespaces/raw/api.go
+++ b/ra_wasm_be_rpc/namespaces/raw/api.go
@@ -14,15 +14,16 @@ const (
 	ApiVersion = "1.0"
 )
 
-// API is the RollApp EVM Block Explorer JSON-RPC.
+// API is the RollApp Wasm Block Explorer JSON-RPC.
+// Developers can create custom API for the chain.
 type API struct {
 	ctx     *server.Context
 	logger  log.Logger
 	backend rawberpcbackend.RollAppWasmBackendI
 }
 
-// NewRaeAPI creates an instance of the RollApp EVM Block Explorer API.
-func NewRaeAPI(
+// NewRollAppWasmAPI creates an instance of the RollApp Wasm Block Explorer API.
+func NewRollAppWasmAPI(
 	ctx *server.Context,
 	backend rawberpcbackend.RollAppWasmBackendI,
 ) *API {

--- a/ra_wasm_be_rpc/types/query_client.go
+++ b/ra_wasm_be_rpc/types/query_client.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/types/tx"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	epochstypes "github.com/dymensionxyz/dymension-rdk/x/epochs/types"
+	sequencerstypes "github.com/dymensionxyz/dymension-rdk/x/sequencers/types"
+)
+
+// QueryClient defines a gRPC Client used for:
+//   - Transaction simulation
+type QueryClient struct {
+	tx.ServiceClient
+
+	BankQueryClient       banktypes.QueryClient
+	SequencersQueryClient sequencerstypes.QueryClient
+	EpochQueryClient      epochstypes.QueryClient
+}
+
+// NewQueryClient creates a new gRPC query client
+func NewQueryClient(clientCtx client.Context) *QueryClient {
+	return &QueryClient{
+		ServiceClient:         tx.NewServiceClient(clientCtx),
+		BankQueryClient:       banktypes.NewQueryClient(clientCtx),
+		SequencersQueryClient: sequencerstypes.NewQueryClient(clientCtx),
+		EpochQueryClient:      epochstypes.NewQueryClient(clientCtx),
+	}
+}

--- a/rollappd/cmd/root.go
+++ b/rollappd/cmd/root.go
@@ -33,6 +33,7 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 
+	berpcconfig "github.com/bcdevtools/block-explorer-rpc-cosmos/be_rpc/config"
 	rdkserver "github.com/dymensionxyz/dymension-rdk/server"
 	"github.com/dymensionxyz/dymension-rdk/utils"
 	dymintconf "github.com/dymensionxyz/dymint/config"
@@ -101,6 +102,9 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 			home := serverCtx.Viper.GetString(tmcli.HomeFlag)
 			chainID := client.GetClientContextFromCmd(cmd).ChainID
 			dymintconf.EnsureRoot(home, dymintconf.DefaultConfig(home, chainID))
+
+			//create Block Explorer Json-RPC toml config file
+			berpcconfig.EnsureRoot(home, berpcconfig.DefaultBeJsonRpcConfig())
 
 			return nil
 		},

--- a/rollappd/cmd/start.go
+++ b/rollappd/cmd/start.go
@@ -8,7 +8,6 @@ import (
 	berpccfg "github.com/bcdevtools/block-explorer-rpc-cosmos/be_rpc/config"
 	berpctypes "github.com/bcdevtools/block-explorer-rpc-cosmos/be_rpc/types"
 	berpcserver "github.com/bcdevtools/block-explorer-rpc-cosmos/server"
-	iberpcbackend "github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/integrate_be_rpc/backend"
 	wasmberpcbackend "github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/integrate_be_rpc/backend/wasm"
 	bemsgparsers "github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/integrate_be_rpc/message_parsers"
 	wasmbeapi "github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/integrate_be_rpc/namespaces/wasm"
@@ -432,7 +431,7 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 
 		wasmBeRpcBackend := wasmberpcbackend.NewWasmBackend(ctx, ctx.Logger, clientCtx, externalServices)
 
-		raeBeRpcBackend := rawberpcbackend.NewRollAppWasmBackend(ctx, ctx.Logger, clientCtx)
+		rawBeRpcBackend := rawberpcbackend.NewRollAppWasmBackend(ctx, ctx.Logger, clientCtx)
 
 		// register application APIs
 
@@ -465,7 +464,7 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 				{
 					Namespace: rawbeapi.DymRollAppWasmBlockExplorerNamespace,
 					Version:   rawbeapi.ApiVersion,
-					Service:   rawbeapi.NewRaeAPI(ctx, raeBeRpcBackend),
+					Service:   rawbeapi.NewRollAppWasmAPI(ctx, rawBeRpcBackend),
 					Public:    true,
 				},
 			}
@@ -481,7 +480,6 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 				// return wasmBeRpcBackend.GetWasmTransactionInvolversByHash()
 			})
 		*/
-
 		//
 
 		genDoc, err := genDocProvider()
@@ -499,8 +497,8 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 			func(backend berpcbackend.BackendI) berpcbackend.RequestInterceptor {
 				return rawberpcbackend.NewRollAppEvmRequestInterceptor(
 					backend,
-					raeBeRpcBackend,
-					iberpcbackend.NewDefaultRequestInterceptor(backend, wasmBeRpcBackend),
+					rawBeRpcBackend,
+					wasmberpcbackend.NewDefaultRequestInterceptor(backend, wasmBeRpcBackend),
 				)
 			},
 			externalServices,

--- a/rollappd/cmd/start.go
+++ b/rollappd/cmd/start.go
@@ -8,10 +8,10 @@ import (
 	berpccfg "github.com/bcdevtools/block-explorer-rpc-cosmos/be_rpc/config"
 	berpctypes "github.com/bcdevtools/block-explorer-rpc-cosmos/be_rpc/types"
 	berpcserver "github.com/bcdevtools/block-explorer-rpc-cosmos/server"
-	iberpcbackend "github.com/bcdevtools/integrate-block-explorer-rpc-cosmos/integrate_be_rpc/backend"
-	wasmberpcbackend "github.com/bcdevtools/integrate-block-explorer-rpc-cosmos/integrate_be_rpc/backend/wasm"
-	bemsgparsers "github.com/bcdevtools/integrate-block-explorer-rpc-cosmos/integrate_be_rpc/message_parsers"
-	wasmbeapi "github.com/bcdevtools/integrate-block-explorer-rpc-cosmos/integrate_be_rpc/namespaces/wasm"
+	iberpcbackend "github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/integrate_be_rpc/backend"
+	wasmberpcbackend "github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/integrate_be_rpc/backend/wasm"
+	bemsgparsers "github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/integrate_be_rpc/message_parsers"
+	wasmbeapi "github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/integrate_be_rpc/namespaces/wasm"
 	rawberpcbackend "github.com/dymensionxyz/rollapp-wasm/ra_wasm_be_rpc/backend"
 	rawbeapi "github.com/dymensionxyz/rollapp-wasm/ra_wasm_be_rpc/namespaces/raw"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -500,7 +500,7 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 				return rawberpcbackend.NewRollAppEvmRequestInterceptor(
 					backend,
 					raeBeRpcBackend,
-					iberpcbackend.NewDefaultRequestInterceptor(backend, nil, wasmBeRpcBackend),
+					iberpcbackend.NewDefaultRequestInterceptor(backend, wasmBeRpcBackend),
 				)
 			},
 			externalServices,

--- a/rollappd/cmd/start.go
+++ b/rollappd/cmd/start.go
@@ -10,6 +10,7 @@ import (
 	berpcserver "github.com/bcdevtools/block-explorer-rpc-cosmos/server"
 	iberpcbackend "github.com/bcdevtools/integrate-block-explorer-rpc-cosmos/integrate_be_rpc/backend"
 	wasmberpcbackend "github.com/bcdevtools/integrate-block-explorer-rpc-cosmos/integrate_be_rpc/backend/wasm"
+	bemsgparsers "github.com/bcdevtools/integrate-block-explorer-rpc-cosmos/integrate_be_rpc/message_parsers"
 	wasmbeapi "github.com/bcdevtools/integrate-block-explorer-rpc-cosmos/integrate_be_rpc/namespaces/wasm"
 	rawberpcbackend "github.com/dymensionxyz/rollapp-wasm/ra_wasm_be_rpc/backend"
 	rawbeapi "github.com/dymensionxyz/rollapp-wasm/ra_wasm_be_rpc/namespaces/raw"
@@ -470,13 +471,14 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 			}
 		}, false)
 
-		// register message involvers extractor
+		// register message parsers & message involvers extractor
+
+		bemsgparsers.RegisterMessageParsersForWasm()
 
 		// TODO BE implement
 		/*
 			berpc.RegisterMessageInvolversExtractor(&Msg_Wasm_Tx{}, func(msg sdk.Msg, _ *tx.Tx, _ tmtypes.Tx, _ client.Context) (berpctypes.MessageInvolversResult, error) {
 				// return wasmBeRpcBackend.GetWasmTransactionInvolversByHash()
-
 			})
 		*/
 

--- a/rollappd/cmd/start.go
+++ b/rollappd/cmd/start.go
@@ -157,9 +157,15 @@ which accepts a path for the resulting pprof file.
 				return err
 			}
 
+			beJsonRpcConfig := berpccfg.DefaultBeJsonRpcConfig()
+			err = beJsonRpcConfig.GetViperConfig(cmd, serverCtx.Viper.GetString(flags.FlagHome))
+			if err != nil {
+				return err
+			}
+
 			// amino is needed here for backwards compatibility of REST routes
 			err = wrapCPUProfile(serverCtx, func() error {
-				return startInProcess(serverCtx, clientCtx, dymconfig, appCreator)
+				return startInProcess(serverCtx, clientCtx, dymconfig, beJsonRpcConfig, appCreator)
 			})
 			errCode, ok := err.(server.ErrorCode)
 			if !ok {
@@ -215,7 +221,7 @@ which accepts a path for the resulting pprof file.
 	return cmd
 }
 
-func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *dymintconf.NodeConfig, appCreator types.AppCreator) error {
+func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *dymintconf.NodeConfig, beRpcCfg *berpccfg.BeJsonRpcConfig, appCreator types.AppCreator) error {
 	cfg := ctx.Config
 	home := cfg.RootDir
 
@@ -237,11 +243,6 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 	}
 
 	if err := config.ValidateBasic(); err != nil {
-		return err
-	}
-
-	beRpcCfg, err := berpccfg.GetConfig(ctx.Viper)
-	if err != nil {
 		return err
 	}
 
@@ -429,7 +430,7 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 			ctx,
 			clientCtx,
 			genDoc.ChainID,
-			beRpcCfg,
+			*beRpcCfg,
 			nil, // external services modifier
 			func(i wasmberpcbackend.WasmBackendI) {
 				berpc.RegisterAPINamespace(rawbeapi.DymRollAppWasmBlockExplorerNamespace, func(ctx *server.Context,

--- a/rollappd/cmd/start.go
+++ b/rollappd/cmd/start.go
@@ -433,7 +433,7 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 			*beRpcCfg,
 			nil, // external services modifier
 			func(i wasmberpcbackend.WasmBackendI) {
-				berpc.RegisterAPINamespace(rawbeapi.DymRollAppWasmBlockExplorerNamespace, func(ctx *server.Context,
+				_ = berpc.RegisterAPINamespace(rawbeapi.DymRollAppWasmBlockExplorerNamespace, func(ctx *server.Context,
 					_ client.Context,
 					_ *rpcclient.WSClient,
 					_ map[string]berpctypes.MessageParser,


### PR DESCRIPTION
This PR integrate the Block Explorer Json-RPC server.
Later, once the Block Explorer service deployed, it can start connecting to the Json-RPC service on RollApp nodes for querying data.

New materials added:
- https://github.com/bcdevtools/block-explorer-rpc-cosmos is the skeleton for the Block Explorer Json-RPC service
- https://github.com/bcdevtools/wasm-block-explorer-rpc-cosmos is the extended version for Cosmwasm