### PR TITLE
chores(deps): bumps `block-explorer-rpc-cosmos v1.0.3` & `wasm-block-explorer-rpc-cosmos v1.0.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,5 +63,5 @@ Templates for Unreleased:
 
 ### Improvements
 
-- (deps) [#42](https://github.com/dymensionxyz/rollapp-wasm/issues/42) Bumps `block-explorer-rpc-cosmos v1.0.2` & `wasm-block-explorer-rpc-cosmos` v1.0.2
-- (deps) [#44](https://github.com/dymensionxyz/rollapp-wasm/issues/44) Bumps `block-explorer-rpc-cosmos v1.0.3`
+- (deps) [#42](https://github.com/dymensionxyz/rollapp-wasm/issues/42) Bumps `block-explorer-rpc-cosmos v1.0.2` & `wasm-block-explorer-rpc-cosmos v1.0.2`
+- (deps) [#44](https://github.com/dymensionxyz/rollapp-wasm/issues/44) Bumps `block-explorer-rpc-cosmos v1.0.3` & `wasm-block-explorer-rpc-cosmos v1.0.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+<!--
+Guiding Principles:
+
+Changelogs are for humans, not machines.
+There should be an entry for every single version.
+The same types of changes should be grouped.
+Versions and sections should be linkable.
+The latest version comes first.
+The release date of each version is displayed.
+Mention whether you follow Semantic Versioning.
+
+Usage:
+
+Change log entries are to be added to the Unreleased section under the
+appropriate stanza (see below). Each entry should ideally include a tag and
+the GitHub issue reference in the following format:
+
+* (<tag>) \#<issue-number> message
+
+Tag must include `sql` if having any changes relate to schema
+
+The issue numbers will later be link-ified during the release process,
+so you do not have to worry about including a link manually, but you can if you wish.
+
+Types of changes (Stanzas):
+
+"Features" for new features.
+"Improvements" for changes in existing functionality.
+"Deprecated" for soon-to-be removed features.
+"Bug Fixes" for any bug fixes.
+"Client Breaking" for breaking CLI commands and REST routes used by end-users.
+"API Breaking" for breaking exported APIs used by developers building on SDK.
+"State Machine Breaking" for any changes that result in a different AppState
+given same genesisState and txList.
+
+If any PR belong to multiple types of change, reference it into all types with only ticket id, no need description (convention)
+
+Ref: https://keepachangelog.com/en/1.0.0/
+-->
+
+<!--
+Templates for Unreleased:
+
+## Unreleased
+
+#### Features
+
+#### Improvements
+
+#### Bug Fixes
+
+#### Client Breaking
+
+#### API Breaking
+
+#### State Machine Breaking
+
+-->
+
+# Changelog
+
+## Unreleased
+
+#### Improvements
+- (deps) [#42](https://github.com/dymensionxyz/rollapp-wasm/issues/42) Bumps `block-explorer-rpc-cosmos v1.0.2` & `wasm-block-explorer-rpc-cosmos` v1.0.2
+- (deps) [#44](https://github.com/dymensionxyz/rollapp-wasm/issues/44) Bumps `block-explorer-rpc-cosmos v1.0.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,17 +43,17 @@ Templates for Unreleased:
 
 ## Unreleased
 
-#### Features
+### Features
 
-#### Improvements
+### Improvements
 
-#### Bug Fixes
+### Bug Fixes
 
-#### Client Breaking
+### Client Breaking
 
-#### API Breaking
+### API Breaking
 
-#### State Machine Breaking
+### State Machine Breaking
 
 -->
 
@@ -61,6 +61,7 @@ Templates for Unreleased:
 
 ## Unreleased
 
-#### Improvements
+### Improvements
+
 - (deps) [#42](https://github.com/dymensionxyz/rollapp-wasm/issues/42) Bumps `block-explorer-rpc-cosmos v1.0.2` & `wasm-block-explorer-rpc-cosmos` v1.0.2
 - (deps) [#44](https://github.com/dymensionxyz/rollapp-wasm/issues/44) Bumps `block-explorer-rpc-cosmos v1.0.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,4 +64,4 @@ Templates for Unreleased:
 ### Improvements
 
 - (deps) [#42](https://github.com/dymensionxyz/rollapp-wasm/issues/42) Bumps `block-explorer-rpc-cosmos v1.0.2` & `wasm-block-explorer-rpc-cosmos v1.0.2`
-- (deps) [#44](https://github.com/dymensionxyz/rollapp-wasm/issues/44) Bumps `block-explorer-rpc-cosmos v1.0.3` & `wasm-block-explorer-rpc-cosmos v1.0.3`
+- (deps) [#45](https://github.com/dymensionxyz/rollapp-wasm/issues/45) Bumps `block-explorer-rpc-cosmos v1.0.3` & `wasm-block-explorer-rpc-cosmos v1.0.3`

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.1
 require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	github.com/CosmWasm/wasmd v0.33.0
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3
 	github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.2
 	github.com/cosmos/cosmos-sdk v0.46.15
 	github.com/cosmos/ibc-go/v6 v6.3.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	github.com/CosmWasm/wasmd v0.33.0
 	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3
-	github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.2
+	github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.3
 	github.com/cosmos/cosmos-sdk v0.46.15
 	github.com/cosmos/ibc-go/v6 v6.3.0
 	github.com/dymensionxyz/dymension-rdk v1.2.0-beta

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxq
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
 github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3 h1:TBC6STStcirdPrUGvsJf4Q07x8lka8Fz24OV5NHFBdA=
 github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
-github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.2 h1:cGbafUCyRyDtK1eQTKOX2MYnX0KtjJHYOL9AYkEz9gU=
-github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.2/go.mod h1:tWGjBIWpKGiFRnhz2Oa9JjVzeKd3RKbGHWRTVXZAquE=
+github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.3 h1:UPPRh+uXOMgzyXvTQFaojvVF3D24hYaTfNG45iBCy68=
+github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.3/go.mod h1:NX8l/hBC6rjww59X+21QkMyItiyi0A+wqV/a0HW3I5w=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2 h1:184TNBIvyozlPy12CPgXvmY/YcWN+ur2m0qA5vlHMQY=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3 h1:TBC6STStcirdPrUGvsJf4Q07x8lka8Fz24OV5NHFBdA=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
 github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.2 h1:cGbafUCyRyDtK1eQTKOX2MYnX0KtjJHYOL9AYkEz9gU=
 github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.2/go.mod h1:tWGjBIWpKGiFRnhz2Oa9JjVzeKd3RKbGHWRTVXZAquE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/ra_wasm_be_rpc/backend/rollapp_wasm_interceptor.go
+++ b/ra_wasm_be_rpc/backend/rollapp_wasm_interceptor.go
@@ -8,37 +8,37 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var _ berpcbackend.RequestInterceptor = (*RollAppEvmRequestInterceptor)(nil)
+var _ berpcbackend.RequestInterceptor = (*RollAppWasmRequestInterceptor)(nil)
 
-type RollAppEvmRequestInterceptor struct {
+type RollAppWasmRequestInterceptor struct {
 	beRpcBackend       berpcbackend.BackendI
 	backend            RollAppWasmBackendI
 	defaultInterceptor berpcbackend.RequestInterceptor
 }
 
-func NewRollAppEvmRequestInterceptor(
+func NewRollAppWasmRequestInterceptor(
 	beRpcBackend berpcbackend.BackendI,
 	backend RollAppWasmBackendI,
 	defaultInterceptor berpcbackend.RequestInterceptor,
-) *RollAppEvmRequestInterceptor {
-	return &RollAppEvmRequestInterceptor{
+) *RollAppWasmRequestInterceptor {
+	return &RollAppWasmRequestInterceptor{
 		beRpcBackend:       beRpcBackend,
 		backend:            backend,
 		defaultInterceptor: defaultInterceptor,
 	}
 }
 
-func (m *RollAppEvmRequestInterceptor) GetTransactionByHash(hashStr string) (intercepted bool, response berpctypes.GenericBackendResponse, err error) {
+func (m *RollAppWasmRequestInterceptor) GetTransactionByHash(hashStr string) (intercepted bool, response berpctypes.GenericBackendResponse, err error) {
 	// handled completely by the default interceptor
 	return m.defaultInterceptor.GetTransactionByHash(hashStr)
 }
 
-func (m *RollAppEvmRequestInterceptor) GetDenomsInformation() (intercepted, append bool, denoms map[string]string, err error) {
+func (m *RollAppWasmRequestInterceptor) GetDenomsInformation() (intercepted, append bool, denoms map[string]string, err error) {
 	// handled completely by the default interceptor
 	return m.defaultInterceptor.GetDenomsInformation()
 }
 
-func (m *RollAppEvmRequestInterceptor) GetModuleParams(moduleName string) (intercepted bool, res berpctypes.GenericBackendResponse, err error) {
+func (m *RollAppWasmRequestInterceptor) GetModuleParams(moduleName string) (intercepted bool, res berpctypes.GenericBackendResponse, err error) {
 	var params any
 
 	switch moduleName {
@@ -67,7 +67,7 @@ func (m *RollAppEvmRequestInterceptor) GetModuleParams(moduleName string) (inter
 	return
 }
 
-func (m *RollAppEvmRequestInterceptor) GetAccount(accountAddressStr string) (intercepted, append bool, response berpctypes.GenericBackendResponse, err error) {
+func (m *RollAppWasmRequestInterceptor) GetAccount(accountAddressStr string) (intercepted, append bool, response berpctypes.GenericBackendResponse, err error) {
 	// handled completely by the default interceptor
 	return m.defaultInterceptor.GetAccount(accountAddressStr)
 }

--- a/rollappd/cmd/start.go
+++ b/rollappd/cmd/start.go
@@ -468,7 +468,7 @@ func startInProcess(ctx *server.Context, clientCtx client.Context, nodeConfig *d
 				}, false)
 			},
 			func(backend berpcbackend.BackendI, wasmBeRpcBackend wasmberpcbackend.WasmBackendI) berpcbackend.RequestInterceptor {
-				return rawberpcbackend.NewRollAppEvmRequestInterceptor(
+				return rawberpcbackend.NewRollAppWasmRequestInterceptor(
 					backend,
 					rawBeRpcBackend,
 					wasmberpcbackend.NewDefaultRequestInterceptor(backend, wasmBeRpcBackend),


### PR DESCRIPTION
This PR update version for 2 dependencies:
- [github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2 → v1.0.3](https://github.com/bcdevtools/block-explorer-rpc-cosmos/compare/v1.0.2...v1.0.3)
- [github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.2 → v1.0.3](https://github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/compare/v1.0.2...v1.0.3)

Content:
- Add new RPC endpoint `be_getLatestBlockNumber` for performance reason.
- `be_getAccount` returns contract code-id to determine if the given address is a contract.
- Correct name for an invalid named struct.