### PR TITLE
chores(deps): bumps `block-explorer-rpc-cosmos` and `wasm-block-explorer-rpc-cosmos` to v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,7 @@ Templates for Unreleased:
 
 - (deps) [#42](https://github.com/dymensionxyz/rollapp-wasm/issues/42) Bumps `block-explorer-rpc-cosmos v1.0.2` & `wasm-block-explorer-rpc-cosmos v1.0.2`
 - (deps) [#45](https://github.com/dymensionxyz/rollapp-wasm/issues/45) Bumps `block-explorer-rpc-cosmos v1.0.3` & `wasm-block-explorer-rpc-cosmos v1.0.3`
+
+### API Breaking
+
+- (deps) [#49](https://github.com/dymensionxyz/rollapp-wasm/issues/49) Bumps `block-explorer-rpc-cosmos v1.1.1` & `wasm-block-explorer-rpc-cosmos v1.1.1`

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.22.1
 require (
 	cosmossdk.io/errors v1.0.1
 	github.com/CosmWasm/wasmd v0.33.0
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3
-	github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.3
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.1
+	github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.1.1
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.3.0
 	github.com/dymensionxyz/dymension-rdk v1.2.0-beta

--- a/go.sum
+++ b/go.sum
@@ -295,10 +295,10 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3 h1:TBC6STStcirdPrUGvsJf4Q07x8lka8Fz24OV5NHFBdA=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
-github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.3 h1:UPPRh+uXOMgzyXvTQFaojvVF3D24hYaTfNG45iBCy68=
-github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.3/go.mod h1:NX8l/hBC6rjww59X+21QkMyItiyi0A+wqV/a0HW3I5w=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.1 h1:GnHtsbNVEdofa0NgunqDsiNJixsy65WVllh40jkxAy0=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.1/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.1.1 h1:cLojf/WPvKXQZMtnt7Agf9ggmYFJrTBPcL1XBihRbxc=
+github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.1.1/go.mod h1:UfmiHm431foFuByYwcsPrYBNll0knPH1o6ulec5VY04=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=


### PR DESCRIPTION
This PR update version for 2 dependencies:
- [github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3 → v1.1.1](https://github.com/bcdevtools/block-explorer-rpc-cosmos/compare/v1.0.3...v1.1.1)
- [github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.0.3 → v1.1.1](https://github.com/bcdevtools/wasm-block-explorer-rpc-cosmos/compare/v1.0.3...v1.1.1)

Content:
- Fix issue token contract balance of address not tracked.
- Response additional details of Wasm tx for indexer.
- Response additional field proto-type for account detection.
- Separate involvers extractor for wasm.