### PR TITLE
chores(deps): bumps `block-explorer-rpc-cosmos v1.2.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,4 +20,5 @@
 
 * **be:** bumps `block-explorer-rpc-cosmos v1.0.2` & `wasm-block-explorer-rpc-cosmos v1.0.2` ([#42](https://github.com/dymensionxyz/rollapp-wasm/issues/42)) ([eab8283](https://github.com/dymensionxyz/rollapp-wasm/commit/eab82830f8ac5586cdc5d67f134fe52cda48f502))
 * **be:** bumps `block-explorer-rpc-cosmos v1.0.3` & `wasm-block-explorer-rpc-cosmos v1.0.3` ([#45](https://github.com/dymensionxyz/rollapp-wasm/issues/45)) ([349bb7c](https://github.com/dymensionxyz/rollapp-wasm/commit/349bb7cf51b954aba087f951bdce02f914d32d6c))
-* **be:** bumps `block-explorer-rpc-cosmos v1.1.2` & `wasm-block-explorer-rpc-cosmos v1.1.2` ([#55](https://github.com/dymensionxyz/rollapp-wasm/issues/55))
+* **be:** bumps `block-explorer-rpc-cosmos v1.1.2` & `wasm-block-explorer-rpc-cosmos v1.1.2` ([#55](https://github.com/dymensionxyz/rollapp-wasm/issues/55)) ([15c563b](https://github.com/dymensionxyz/rollapp-wasm/commit/15c563b10b8e2e5be4d85acfa4362ddd711bf377))
+* **be:** bumps `block-explorer-rpc-cosmos v1.2.3` ([#76](https://github.com/dymensionxyz/rollapp-wasm/issues/76))

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.3
 require (
 	cosmossdk.io/errors v1.0.1
 	github.com/CosmWasm/wasmd v0.33.0
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.2
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.3
 	github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.1.1
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.3.0

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.2 h1:XS/OOOWXaAvFQ06qzrZStCkayQ8ZOEJM3zE6Pp/rOn4=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.2/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.3 h1:nF9aC1/fTW4hb/DWO+/D4+FWD+NIh1QHp7sVjzWdJZY=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.3/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
 github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.1.1 h1:cLojf/WPvKXQZMtnt7Agf9ggmYFJrTBPcL1XBihRbxc=
 github.com/bcdevtools/wasm-block-explorer-rpc-cosmos v1.1.1/go.mod h1:UfmiHm431foFuByYwcsPrYBNll0knPH1o6ulec5VY04=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
This PR update version for 1 dependency:
- [github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.2 → v1.2.3](https://github.com/bcdevtools/block-explorer-rpc-cosmos/compare/v1.1.2...v1.2.3)

Content:
- Add new API for performance and data consistency when querying via load-balancer.
- Improve content returns for indexer.
- Improve content returns by RPC.
- Fix some bugs.
- Fix RPC handler crash.
